### PR TITLE
[REFACTOR] Make sure that this logger's configuration is safe.

### DIFF
--- a/algorithm-exercises-java/src/main/java/ae/projecteuler/util/CustomLogger.java
+++ b/algorithm-exercises-java/src/main/java/ae/projecteuler/util/CustomLogger.java
@@ -13,7 +13,7 @@ public class CustomLogger {
   /**
    * Common logger singleton.
    */
-  @SuppressWarnings({"java:S106"})
+  @SuppressWarnings({"java:S106", "java:S4792"})
   public static java.util.logging.Logger getLogger() {
 
     // default log level


### PR DESCRIPTION
Configuring loggers is security-sensitivejava:S4792

The logger was deliberately set up to observe the internal flow of some more complex algorithm exercises.