### PR TITLE
[CONFIG] [Github Actions] Avoid run on "push" for dependabot triggere…

### DIFF
--- a/.github/workflows/snyk-code.yml
+++ b/.github/workflows/snyk-code.yml
@@ -3,8 +3,11 @@
 name: Snyk Code (Java gradle-jdk17)
 
 on: # yamllint disable-line rule:truthy
-  push:
   pull_request:
+  push:
+    branches:
+      - '**'        # matches every branch
+      - '!dependabot/**'   # excludes master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
…d actions.

Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches. See https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#scanning-on-push for more information on how to configure these events.

https://stackoverflow.com/a/57903434/6366150